### PR TITLE
Add PSK v1.1 protocol support

### DIFF
--- a/src/app/core/psk/index.ts
+++ b/src/app/core/psk/index.ts
@@ -1,0 +1,56 @@
+/**
+ * PSK Protocol v1.1 - Barrel Export
+ *
+ * Pre-shared key messaging for AlgoChat.
+ */
+
+// Types and constants
+export { PSK_PROTOCOL, PSK_HKDF, type PSKEnvelope, type PSKState } from './psk-types';
+
+// Ratchet key derivation
+export {
+    deriveSessionPSK,
+    derivePositionPSK,
+    derivePSKAtCounter,
+    deriveHybridSymmetricKey,
+    deriveSenderKey,
+} from './psk-ratchet';
+
+// Envelope encoding/decoding
+export {
+    encodePSKEnvelope,
+    decodePSKEnvelope,
+    isPSKMessage,
+    PSKEnvelopeError,
+} from './psk-envelope';
+
+// Counter state management
+export {
+    createPSKState,
+    advanceSendCounter,
+    validateReceiveCounter,
+    recordReceivedCounter,
+    serializePSKState,
+    deserializePSKState,
+    PSKCounterError,
+} from './psk-state';
+
+// Key exchange URI
+export {
+    createPSKExchangeURI,
+    parsePSKExchangeURI,
+    generatePSK,
+    PSKExchangeError,
+    type PSKExchangeURI,
+} from './psk-exchange';
+
+// Encryption/decryption
+export {
+    pskEncryptMessage,
+    pskDecryptMessage,
+    PSKEncryptionError,
+    type PSKDecryptedContent,
+} from './psk-encryption';
+
+// Angular service
+export { PSKService } from './psk.service';

--- a/src/app/core/psk/psk-encryption.ts
+++ b/src/app/core/psk/psk-encryption.ts
@@ -1,0 +1,222 @@
+/**
+ * PSK Protocol v1.1 - Hybrid ECDH+PSK Encryption
+ *
+ * Encrypts and decrypts messages using a combination of ephemeral ECDH
+ * key agreement and a ratcheted pre-shared key. This provides both
+ * forward secrecy (from ephemeral keys) and authentication (from PSK).
+ */
+
+import { chacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { randomBytes } from '@noble/ciphers/utils.js';
+import { x25519 } from '@noble/curves/ed25519.js';
+import { uint8ArrayEquals } from 'ts-algochat';
+import { PSK_PROTOCOL, type PSKEnvelope } from './psk-types';
+import {
+    derivePSKAtCounter,
+    deriveHybridSymmetricKey,
+    deriveSenderKey,
+} from './psk-ratchet';
+
+export class PSKEncryptionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PSKEncryptionError';
+    }
+}
+
+/** Decrypted PSK message content */
+export interface PSKDecryptedContent {
+    text: string;
+    counter: number;
+    replyToId?: string;
+    replyToPreview?: string;
+}
+
+/**
+ * Encrypts a message using the PSK v1.1 protocol.
+ *
+ * @param plaintext - Message text to encrypt
+ * @param senderPublicKey - Sender's X25519 public key
+ * @param recipientPublicKey - Recipient's X25519 public key
+ * @param initialPSK - 32-byte initial pre-shared key
+ * @param counter - Current send counter value
+ */
+export function pskEncryptMessage(
+    plaintext: string,
+    senderPublicKey: Uint8Array,
+    recipientPublicKey: Uint8Array,
+    initialPSK: Uint8Array,
+    counter: number
+): PSKEnvelope {
+    const messageBytes = new TextEncoder().encode(plaintext);
+
+    if (messageBytes.length > PSK_PROTOCOL.MAX_PAYLOAD_SIZE) {
+        throw new PSKEncryptionError(
+            `Message too large: ${messageBytes.length} bytes, max ${PSK_PROTOCOL.MAX_PAYLOAD_SIZE}`
+        );
+    }
+
+    // Step 1: Derive the current PSK from the ratchet
+    const currentPSK = derivePSKAtCounter(initialPSK, counter);
+
+    // Step 2: Generate ephemeral key pair
+    const ephPriv = x25519.utils.randomSecretKey();
+    const ephPub = x25519.getPublicKey(ephPriv);
+
+    // Step 3: ECDH shared secret with recipient
+    const sharedSecret = x25519.getSharedSecret(ephPriv, recipientPublicKey);
+
+    // Step 4: Derive hybrid symmetric key (ECDH + PSK)
+    const symmetricKey = deriveHybridSymmetricKey(
+        sharedSecret,
+        currentPSK,
+        ephPub,
+        senderPublicKey,
+        recipientPublicKey
+    );
+
+    // Step 5: Encrypt message
+    const nonce = randomBytes(12);
+    const cipher = chacha20poly1305(symmetricKey, nonce);
+    const ciphertextWithTag = cipher.encrypt(messageBytes);
+
+    // Step 6: Encrypt symmetric key for sender (bidirectional decryption)
+    const senderSharedSecret = x25519.getSharedSecret(ephPriv, senderPublicKey);
+    const senderEncryptionKey = deriveSenderKey(
+        senderSharedSecret,
+        currentPSK,
+        ephPub,
+        senderPublicKey
+    );
+
+    const senderCipher = chacha20poly1305(senderEncryptionKey, nonce);
+    const encryptedSenderKey = senderCipher.encrypt(symmetricKey);
+
+    return {
+        version: PSK_PROTOCOL.VERSION,
+        protocolId: PSK_PROTOCOL.PROTOCOL_ID,
+        counter,
+        senderPublicKey,
+        ephemeralPublicKey: ephPub,
+        nonce,
+        encryptedSenderKey,
+        ciphertext: ciphertextWithTag,
+    };
+}
+
+/**
+ * Decrypts a PSK v1.1 message.
+ *
+ * Automatically detects if we are the sender or recipient
+ * and uses the appropriate decryption path.
+ *
+ * @param envelope - The PSK envelope to decrypt
+ * @param myPrivateKey - Our X25519 private key
+ * @param myPublicKey - Our X25519 public key
+ * @param initialPSK - 32-byte initial pre-shared key
+ */
+export function pskDecryptMessage(
+    envelope: PSKEnvelope,
+    myPrivateKey: Uint8Array,
+    myPublicKey: Uint8Array,
+    initialPSK: Uint8Array
+): PSKDecryptedContent | null {
+    const weAreSender = uint8ArrayEquals(myPublicKey, envelope.senderPublicKey);
+
+    // Derive the current PSK from the ratchet at the envelope's counter
+    const currentPSK = derivePSKAtCounter(initialPSK, envelope.counter);
+
+    let plaintext: Uint8Array;
+
+    if (weAreSender) {
+        plaintext = pskDecryptAsSender(envelope, myPrivateKey, myPublicKey, currentPSK);
+    } else {
+        plaintext = pskDecryptAsRecipient(envelope, myPrivateKey, myPublicKey, currentPSK);
+    }
+
+    return parsePSKPayload(plaintext, envelope.counter);
+}
+
+/**
+ * Decrypts as the message recipient using hybrid ECDH+PSK.
+ */
+function pskDecryptAsRecipient(
+    envelope: PSKEnvelope,
+    recipientPrivateKey: Uint8Array,
+    recipientPublicKey: Uint8Array,
+    currentPSK: Uint8Array
+): Uint8Array {
+    // ECDH with ephemeral key
+    const sharedSecret = x25519.getSharedSecret(recipientPrivateKey, envelope.ephemeralPublicKey);
+
+    // Derive hybrid symmetric key
+    const symmetricKey = deriveHybridSymmetricKey(
+        sharedSecret,
+        currentPSK,
+        envelope.ephemeralPublicKey,
+        envelope.senderPublicKey,
+        recipientPublicKey
+    );
+
+    // Decrypt message
+    const cipher = chacha20poly1305(symmetricKey, envelope.nonce);
+    return cipher.decrypt(envelope.ciphertext);
+}
+
+/**
+ * Decrypts as the message sender using the encrypted sender key.
+ */
+function pskDecryptAsSender(
+    envelope: PSKEnvelope,
+    senderPrivateKey: Uint8Array,
+    senderPublicKey: Uint8Array,
+    currentPSK: Uint8Array
+): Uint8Array {
+    // ECDH with ephemeral key using sender's private key
+    const senderSharedSecret = x25519.getSharedSecret(senderPrivateKey, envelope.ephemeralPublicKey);
+
+    // Derive sender key encryption key
+    const senderDecryptionKey = deriveSenderKey(
+        senderSharedSecret,
+        currentPSK,
+        envelope.ephemeralPublicKey,
+        senderPublicKey
+    );
+
+    // Decrypt the symmetric key
+    const senderCipher = chacha20poly1305(senderDecryptionKey, envelope.nonce);
+    const symmetricKey = senderCipher.decrypt(envelope.encryptedSenderKey);
+
+    // Decrypt the message using the recovered symmetric key
+    const cipher = chacha20poly1305(symmetricKey, envelope.nonce);
+    return cipher.decrypt(envelope.ciphertext);
+}
+
+/**
+ * Parses decrypted PSK message payload.
+ */
+function parsePSKPayload(data: Uint8Array, counter: number): PSKDecryptedContent | null {
+    const text = new TextDecoder().decode(data);
+
+    // Check for key-publish payload
+    if (text.startsWith('{')) {
+        try {
+            const json = JSON.parse(text);
+            if (json.type === 'key-publish') {
+                return null;
+            }
+            if (typeof json.text === 'string') {
+                return {
+                    text: json.text,
+                    counter,
+                    replyToId: json.replyTo?.txid,
+                    replyToPreview: json.replyTo?.preview,
+                };
+            }
+        } catch {
+            // Fall through to plain text
+        }
+    }
+
+    return { text, counter };
+}

--- a/src/app/core/psk/psk-envelope.ts
+++ b/src/app/core/psk/psk-envelope.ts
@@ -1,0 +1,109 @@
+/**
+ * PSK Protocol v1.1 - Envelope Encoding/Decoding
+ *
+ * Wire format (130-byte header):
+ *   [0]:     version (0x01)
+ *   [1]:     protocolId (0x02)
+ *   [2..5]:  counter (big-endian u32)
+ *   [6..37]: senderPublicKey (32 bytes)
+ *   [38..69]: ephemeralPublicKey (32 bytes)
+ *   [70..81]: nonce (12 bytes)
+ *   [82..129]: encryptedSenderKey (48 bytes)
+ *   [130..]:  ciphertext + tag
+ */
+
+import { PSK_PROTOCOL, type PSKEnvelope } from './psk-types';
+
+export class PSKEnvelopeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PSKEnvelopeError';
+    }
+}
+
+/**
+ * Encodes a PSKEnvelope to bytes for transaction note.
+ */
+export function encodePSKEnvelope(envelope: PSKEnvelope): Uint8Array {
+    const totalSize = PSK_PROTOCOL.HEADER_SIZE + envelope.ciphertext.length;
+    const result = new Uint8Array(totalSize);
+    let offset = 0;
+
+    // Version and protocol
+    result[offset++] = envelope.version;
+    result[offset++] = envelope.protocolId;
+
+    // Counter (4 bytes, big-endian)
+    new DataView(result.buffer).setUint32(offset, envelope.counter, false);
+    offset += 4;
+
+    // Sender public key (32 bytes)
+    result.set(envelope.senderPublicKey, offset);
+    offset += 32;
+
+    // Ephemeral public key (32 bytes)
+    result.set(envelope.ephemeralPublicKey, offset);
+    offset += 32;
+
+    // Nonce (12 bytes)
+    result.set(envelope.nonce, offset);
+    offset += 12;
+
+    // Encrypted sender key (48 bytes)
+    result.set(envelope.encryptedSenderKey, offset);
+    offset += 48;
+
+    // Ciphertext + tag
+    result.set(envelope.ciphertext, offset);
+
+    return result;
+}
+
+/**
+ * Decodes bytes from transaction note to PSKEnvelope.
+ */
+export function decodePSKEnvelope(data: Uint8Array): PSKEnvelope {
+    if (data.length < 2) {
+        throw new PSKEnvelopeError(`Data too short: ${data.length} bytes`);
+    }
+
+    const version = data[0];
+    const protocolId = data[1];
+
+    if (version !== PSK_PROTOCOL.VERSION) {
+        throw new PSKEnvelopeError(`Unsupported version: ${version}`);
+    }
+
+    if (protocolId !== PSK_PROTOCOL.PROTOCOL_ID) {
+        throw new PSKEnvelopeError(`Not a PSK envelope: protocol ${protocolId}`);
+    }
+
+    const minSize = PSK_PROTOCOL.HEADER_SIZE + PSK_PROTOCOL.TAG_SIZE;
+    if (data.length < minSize) {
+        throw new PSKEnvelopeError(`Data too short: ${data.length} bytes, need at least ${minSize}`);
+    }
+
+    const counter = new DataView(data.buffer, data.byteOffset).getUint32(2, false);
+
+    return {
+        version,
+        protocolId,
+        counter,
+        senderPublicKey: data.slice(6, 38),
+        ephemeralPublicKey: data.slice(38, 70),
+        nonce: data.slice(70, 82),
+        encryptedSenderKey: data.slice(82, 130),
+        ciphertext: data.slice(130),
+    };
+}
+
+/**
+ * Checks if data is a PSK v1.1 message (version=0x01, protocol=0x02).
+ */
+export function isPSKMessage(data: Uint8Array): boolean {
+    return (
+        data.length >= PSK_PROTOCOL.HEADER_SIZE + PSK_PROTOCOL.TAG_SIZE &&
+        data[0] === PSK_PROTOCOL.VERSION &&
+        data[1] === PSK_PROTOCOL.PROTOCOL_ID
+    );
+}

--- a/src/app/core/psk/psk-exchange.ts
+++ b/src/app/core/psk/psk-exchange.ts
@@ -1,0 +1,117 @@
+/**
+ * PSK Protocol v1.1 - Key Exchange URI
+ *
+ * Generates and parses PSK exchange URIs for out-of-band key sharing.
+ * Format: algochat-psk://v1?addr=<address>&psk=<base64url>&label=<label>
+ */
+
+export class PSKExchangeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PSKExchangeError';
+    }
+}
+
+/** Parsed PSK exchange URI */
+export interface PSKExchangeURI {
+    address: string;
+    psk: Uint8Array;
+    label: string;
+}
+
+/**
+ * Creates a PSK exchange URI.
+ *
+ * @param address - Algorand address of the PSK owner
+ * @param psk - 32-byte pre-shared key
+ * @param label - Human-readable label for the contact
+ */
+export function createPSKExchangeURI(
+    address: string,
+    psk: Uint8Array,
+    label: string
+): string {
+    if (psk.length !== 32) {
+        throw new PSKExchangeError(`PSK must be 32 bytes, got ${psk.length}`);
+    }
+
+    const pskBase64url = uint8ArrayToBase64url(psk);
+    const encodedLabel = encodeURIComponent(label);
+
+    return `algochat-psk://v1?addr=${address}&psk=${pskBase64url}&label=${encodedLabel}`;
+}
+
+/**
+ * Parses a PSK exchange URI.
+ *
+ * @param uri - The PSK exchange URI string
+ * @returns Parsed exchange data
+ */
+export function parsePSKExchangeURI(uri: string): PSKExchangeURI {
+    if (!uri.startsWith('algochat-psk://v1?')) {
+        throw new PSKExchangeError(`Invalid PSK URI scheme: ${uri.split('?')[0]}`);
+    }
+
+    const queryString = uri.slice('algochat-psk://v1?'.length);
+    const params = new URLSearchParams(queryString);
+
+    const address = params.get('addr');
+    if (!address) {
+        throw new PSKExchangeError('Missing addr parameter');
+    }
+
+    const pskBase64url = params.get('psk');
+    if (!pskBase64url) {
+        throw new PSKExchangeError('Missing psk parameter');
+    }
+
+    const psk = base64urlToUint8Array(pskBase64url);
+    if (psk.length !== 32) {
+        throw new PSKExchangeError(`PSK must be 32 bytes, got ${psk.length}`);
+    }
+
+    const label = params.get('label') ?? '';
+
+    return {
+        address,
+        psk,
+        label: decodeURIComponent(label),
+    };
+}
+
+/**
+ * Generates a random 32-byte PSK.
+ */
+export function generatePSK(): Uint8Array {
+    const psk = new Uint8Array(32);
+    crypto.getRandomValues(psk);
+    return psk;
+}
+
+// --- Base64url helpers ---
+
+function uint8ArrayToBase64url(bytes: Uint8Array): string {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}
+
+function base64urlToUint8Array(base64url: string): Uint8Array {
+    // Convert base64url to standard base64
+    let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    // Add padding
+    const padding = (4 - (base64.length % 4)) % 4;
+    base64 += '='.repeat(padding);
+
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}

--- a/src/app/core/psk/psk-ratchet.ts
+++ b/src/app/core/psk/psk-ratchet.ts
@@ -1,0 +1,107 @@
+/**
+ * PSK Protocol v1.1 - Two-Level Ratchet Key Derivation
+ *
+ * Derives per-message PSKs from an initial pre-shared key using
+ * a two-level HKDF ratchet: session (counter / SESSION_SIZE) and
+ * position (counter % SESSION_SIZE).
+ */
+
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { PSK_PROTOCOL, PSK_HKDF } from './psk-types';
+
+const SESSION_SALT = new TextEncoder().encode(PSK_HKDF.SESSION_SALT);
+const POSITION_SALT = new TextEncoder().encode(PSK_HKDF.POSITION_SALT);
+const HYBRID_INFO_PREFIX = new TextEncoder().encode(PSK_HKDF.HYBRID_INFO_PREFIX);
+const SENDER_KEY_INFO_PREFIX = new TextEncoder().encode(PSK_HKDF.SENDER_KEY_INFO_PREFIX);
+
+/**
+ * Encodes a number as a 4-byte big-endian Uint8Array.
+ */
+function uint32BE(value: number): Uint8Array {
+    const buf = new Uint8Array(4);
+    new DataView(buf.buffer).setUint32(0, value, false);
+    return buf;
+}
+
+/**
+ * Concatenates multiple Uint8Arrays into one.
+ */
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+    const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const arr of arrays) {
+        result.set(arr, offset);
+        offset += arr.length;
+    }
+    return result;
+}
+
+/**
+ * Derives a session-level PSK from the initial PSK.
+ *
+ * HKDF(SHA256, IKM=initialPSK, salt="AlgoChat-PSK-Session", info=sessionIndex as 4-byte BE)
+ */
+export function deriveSessionPSK(initialPSK: Uint8Array, sessionIndex: number): Uint8Array {
+    return hkdf(sha256, initialPSK, SESSION_SALT, uint32BE(sessionIndex), 32);
+}
+
+/**
+ * Derives a position-level PSK from a session PSK.
+ *
+ * HKDF(SHA256, IKM=sessionPSK, salt="AlgoChat-PSK-Position", info=position as 4-byte BE)
+ */
+export function derivePositionPSK(sessionPSK: Uint8Array, position: number): Uint8Array {
+    return hkdf(sha256, sessionPSK, POSITION_SALT, uint32BE(position), 32);
+}
+
+/**
+ * Derives the PSK for a specific counter value using the two-level ratchet.
+ *
+ * session = counter / SESSION_SIZE (integer division)
+ * position = counter % SESSION_SIZE
+ */
+export function derivePSKAtCounter(initialPSK: Uint8Array, counter: number): Uint8Array {
+    const sessionIndex = Math.floor(counter / PSK_PROTOCOL.SESSION_SIZE);
+    const position = counter % PSK_PROTOCOL.SESSION_SIZE;
+    const sessionPSK = deriveSessionPSK(initialPSK, sessionIndex);
+    return derivePositionPSK(sessionPSK, position);
+}
+
+/**
+ * Derives the hybrid symmetric key from ECDH shared secret and PSK.
+ *
+ * IKM = sharedSecret || currentPSK
+ * salt = ephPub
+ * info = "AlgoChatV1-PSK" + senderPub + recipientPub
+ */
+export function deriveHybridSymmetricKey(
+    sharedSecret: Uint8Array,
+    currentPSK: Uint8Array,
+    ephPub: Uint8Array,
+    senderPub: Uint8Array,
+    recipientPub: Uint8Array
+): Uint8Array {
+    const ikm = concatBytes(sharedSecret, currentPSK);
+    const info = concatBytes(HYBRID_INFO_PREFIX, senderPub, recipientPub);
+    return hkdf(sha256, ikm, ephPub, info, 32);
+}
+
+/**
+ * Derives the sender key encryption key from ECDH shared secret and PSK.
+ *
+ * IKM = senderSharedSecret || currentPSK
+ * salt = ephPub
+ * info = "AlgoChatV1-PSK-SenderKey" + senderPub
+ */
+export function deriveSenderKey(
+    senderSharedSecret: Uint8Array,
+    currentPSK: Uint8Array,
+    ephPub: Uint8Array,
+    senderPub: Uint8Array
+): Uint8Array {
+    const ikm = concatBytes(senderSharedSecret, currentPSK);
+    const info = concatBytes(SENDER_KEY_INFO_PREFIX, senderPub);
+    return hkdf(sha256, ikm, ephPub, info, 32);
+}

--- a/src/app/core/psk/psk-state.ts
+++ b/src/app/core/psk/psk-state.ts
@@ -1,0 +1,124 @@
+/**
+ * PSK Protocol v1.1 - Counter State Management
+ *
+ * Manages send/receive counters with a sliding window for replay protection.
+ * The window allows receiving messages within +/- COUNTER_WINDOW of the
+ * highest seen counter, while preventing replays of already-seen counters.
+ */
+
+import { PSK_PROTOCOL, type PSKState } from './psk-types';
+
+export class PSKCounterError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PSKCounterError';
+    }
+}
+
+/**
+ * Creates a new PSK state from an initial pre-shared key.
+ */
+export function createPSKState(initialPSK: Uint8Array): PSKState {
+    if (initialPSK.length !== 32) {
+        throw new PSKCounterError(`PSK must be 32 bytes, got ${initialPSK.length}`);
+    }
+    return {
+        initialPSK: new Uint8Array(initialPSK),
+        sendCounter: 0,
+        receiveCounter: 0,
+        receivedCounters: new Set<number>(),
+    };
+}
+
+/**
+ * Gets the next send counter and advances the state.
+ * Returns the counter value to use for the next outgoing message.
+ */
+export function advanceSendCounter(state: PSKState): number {
+    const counter = state.sendCounter;
+    if (counter > 0xFFFFFFFF) {
+        throw new PSKCounterError('Send counter overflow');
+    }
+    state.sendCounter = counter + 1;
+    return counter;
+}
+
+/**
+ * Validates a received counter against the window.
+ *
+ * A counter is valid if:
+ * 1. It has not been seen before (replay protection)
+ * 2. It is within the window: [receiveCounter - COUNTER_WINDOW, receiveCounter + COUNTER_WINDOW]
+ *
+ * Returns true if the counter is valid and should be accepted.
+ */
+export function validateReceiveCounter(state: PSKState, counter: number): boolean {
+    // Reject already-seen counters
+    if (state.receivedCounters.has(counter)) {
+        return false;
+    }
+
+    // First message ever received - accept anything
+    if (state.receivedCounters.size === 0) {
+        return true;
+    }
+
+    // Check window bounds
+    const lowerBound = Math.max(0, state.receiveCounter - PSK_PROTOCOL.COUNTER_WINDOW);
+    const upperBound = state.receiveCounter + PSK_PROTOCOL.COUNTER_WINDOW;
+
+    return counter >= lowerBound && counter <= upperBound;
+}
+
+/**
+ * Records a successfully received counter and updates the window.
+ * Call this after successfully decrypting and validating a message.
+ */
+export function recordReceivedCounter(state: PSKState, counter: number): void {
+    state.receivedCounters.add(counter);
+
+    // Update high-water mark
+    if (counter > state.receiveCounter) {
+        state.receiveCounter = counter;
+    }
+
+    // Prune counters outside the window
+    pruneCounters(state);
+}
+
+/**
+ * Removes counters that have fallen outside the sliding window.
+ */
+function pruneCounters(state: PSKState): void {
+    const lowerBound = Math.max(0, state.receiveCounter - PSK_PROTOCOL.COUNTER_WINDOW);
+    for (const counter of state.receivedCounters) {
+        if (counter < lowerBound) {
+            state.receivedCounters.delete(counter);
+        }
+    }
+}
+
+/**
+ * Serializes PSK state for storage.
+ */
+export function serializePSKState(state: PSKState): string {
+    return JSON.stringify({
+        initialPSK: Array.from(state.initialPSK),
+        sendCounter: state.sendCounter,
+        receiveCounter: state.receiveCounter,
+        receivedCounters: Array.from(state.receivedCounters),
+    });
+}
+
+/**
+ * Deserializes PSK state from storage.
+ */
+export function deserializePSKState(json: string): PSKState {
+    const data = JSON.parse(json);
+    return {
+        initialPSK: new Uint8Array(data.initialPSK),
+        sendCounter: data.sendCounter,
+        receiveCounter: data.receiveCounter,
+        receivedCounters: new Set<number>(data.receivedCounters),
+    };
+}

--- a/src/app/core/psk/psk-types.ts
+++ b/src/app/core/psk/psk-types.ts
@@ -1,0 +1,50 @@
+/**
+ * PSK Protocol v1.1 - Types and Constants
+ *
+ * Pre-shared key messaging protocol for AlgoChat.
+ * Adds counter-based ratcheting and hybrid ECDH+PSK encryption.
+ */
+
+/** Protocol constants for PSK v1.1 */
+export const PSK_PROTOCOL = {
+    VERSION: 0x01,
+    PROTOCOL_ID: 0x02,
+    HEADER_SIZE: 130,
+    TAG_SIZE: 16,
+    ENCRYPTED_SENDER_KEY_SIZE: 48,
+    MAX_PAYLOAD_SIZE: 878,
+    SESSION_SIZE: 100,
+    COUNTER_WINDOW: 200,
+} as const;
+
+/** HKDF domain separation constants */
+export const PSK_HKDF = {
+    SESSION_SALT: 'AlgoChat-PSK-Session',
+    POSITION_SALT: 'AlgoChat-PSK-Position',
+    HYBRID_INFO_PREFIX: 'AlgoChatV1-PSK',
+    SENDER_KEY_INFO_PREFIX: 'AlgoChatV1-PSK-SenderKey',
+} as const;
+
+/** Parsed PSK envelope from transaction note */
+export interface PSKEnvelope {
+    version: number;
+    protocolId: number;
+    counter: number;
+    senderPublicKey: Uint8Array;
+    ephemeralPublicKey: Uint8Array;
+    nonce: Uint8Array;
+    encryptedSenderKey: Uint8Array;
+    ciphertext: Uint8Array;
+}
+
+/** Mutable PSK state for counter tracking */
+export interface PSKState {
+    /** Initial pre-shared key (32 bytes) */
+    initialPSK: Uint8Array;
+    /** Current send counter (monotonically increasing) */
+    sendCounter: number;
+    /** Highest received counter */
+    receiveCounter: number;
+    /** Set of received counters within the window (for replay protection) */
+    receivedCounters: Set<number>;
+}

--- a/src/app/core/psk/psk.service.ts
+++ b/src/app/core/psk/psk.service.ts
@@ -1,0 +1,225 @@
+/**
+ * PSK Protocol v1.1 - Angular Service
+ *
+ * Manages PSK state, encryption/decryption, and counter tracking
+ * for pre-shared key messaging sessions.
+ */
+
+import { Injectable, signal } from '@angular/core';
+import { type PSKState } from './psk-types';
+import {
+    createPSKState,
+    advanceSendCounter,
+    validateReceiveCounter,
+    recordReceivedCounter,
+    serializePSKState,
+    deserializePSKState,
+} from './psk-state';
+import { pskEncryptMessage, pskDecryptMessage, type PSKDecryptedContent } from './psk-encryption';
+import { encodePSKEnvelope, decodePSKEnvelope, isPSKMessage } from './psk-envelope';
+import { createPSKExchangeURI, parsePSKExchangeURI, generatePSK, type PSKExchangeURI } from './psk-exchange';
+import type { PSKEnvelope } from './psk-types';
+
+const PSK_STORAGE_PREFIX = 'algochat_psk_';
+
+@Injectable({ providedIn: 'root' })
+export class PSKService {
+    /** Active PSK sessions keyed by participant address */
+    private readonly sessions = new Map<string, PSKState>();
+
+    /** Signal for reactive UI updates */
+    readonly activeSessions = signal<string[]>([]);
+
+    /**
+     * Initializes a PSK session with a participant.
+     *
+     * @param address - Participant's Algorand address
+     * @param initialPSK - 32-byte pre-shared key
+     */
+    initSession(address: string, initialPSK: Uint8Array): void {
+        const state = createPSKState(initialPSK);
+        this.sessions.set(address, state);
+        this.updateActiveSessions();
+        this.persistState(address, state);
+    }
+
+    /**
+     * Checks if a PSK session exists for a participant.
+     */
+    hasSession(address: string): boolean {
+        return this.sessions.has(address);
+    }
+
+    /**
+     * Gets the PSK state for a participant.
+     */
+    getState(address: string): PSKState | undefined {
+        return this.sessions.get(address);
+    }
+
+    /**
+     * Removes a PSK session.
+     */
+    removeSession(address: string): void {
+        this.sessions.delete(address);
+        this.updateActiveSessions();
+        this.removePersistedState(address);
+    }
+
+    /**
+     * Encrypts a message for a PSK session.
+     *
+     * @returns Encoded envelope bytes ready for a transaction note
+     */
+    encrypt(
+        address: string,
+        plaintext: string,
+        senderPublicKey: Uint8Array,
+        recipientPublicKey: Uint8Array
+    ): Uint8Array {
+        const state = this.sessions.get(address);
+        if (!state) {
+            throw new Error(`No PSK session for ${address}`);
+        }
+
+        const counter = advanceSendCounter(state);
+        const envelope = pskEncryptMessage(
+            plaintext,
+            senderPublicKey,
+            recipientPublicKey,
+            state.initialPSK,
+            counter
+        );
+
+        this.persistState(address, state);
+        return encodePSKEnvelope(envelope);
+    }
+
+    /**
+     * Decrypts a PSK message from a participant.
+     *
+     * @returns Decrypted content, or null if decryption fails or message is filtered
+     */
+    decrypt(
+        address: string,
+        noteBytes: Uint8Array,
+        myPrivateKey: Uint8Array,
+        myPublicKey: Uint8Array
+    ): PSKDecryptedContent | null {
+        const state = this.sessions.get(address);
+        if (!state) {
+            return null;
+        }
+
+        if (!isPSKMessage(noteBytes)) {
+            return null;
+        }
+
+        const envelope = decodePSKEnvelope(noteBytes);
+
+        // Validate counter
+        if (!validateReceiveCounter(state, envelope.counter)) {
+            return null;
+        }
+
+        const decrypted = pskDecryptMessage(
+            envelope,
+            myPrivateKey,
+            myPublicKey,
+            state.initialPSK
+        );
+
+        if (decrypted) {
+            recordReceivedCounter(state, envelope.counter);
+            this.persistState(address, state);
+        }
+
+        return decrypted;
+    }
+
+    /**
+     * Checks if a transaction note is a PSK message.
+     */
+    isPSKMessage(noteBytes: Uint8Array): boolean {
+        return isPSKMessage(noteBytes);
+    }
+
+    /**
+     * Decodes a PSK envelope without decrypting.
+     */
+    decodeEnvelope(noteBytes: Uint8Array): PSKEnvelope {
+        return decodePSKEnvelope(noteBytes);
+    }
+
+    /**
+     * Generates a new random PSK.
+     */
+    generatePSK(): Uint8Array {
+        return generatePSK();
+    }
+
+    /**
+     * Creates a PSK exchange URI for sharing.
+     */
+    createExchangeURI(address: string, psk: Uint8Array, label: string): string {
+        return createPSKExchangeURI(address, psk, label);
+    }
+
+    /**
+     * Parses a PSK exchange URI.
+     */
+    parseExchangeURI(uri: string): PSKExchangeURI {
+        return parsePSKExchangeURI(uri);
+    }
+
+    /**
+     * Loads all persisted PSK sessions from localStorage.
+     */
+    loadPersistedSessions(): void {
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key?.startsWith(PSK_STORAGE_PREFIX)) {
+                const address = key.slice(PSK_STORAGE_PREFIX.length);
+                const json = localStorage.getItem(key);
+                if (json) {
+                    try {
+                        const state = deserializePSKState(json);
+                        this.sessions.set(address, state);
+                    } catch {
+                        // Skip invalid data
+                        console.warn(`[PSK] Failed to load session for ${address}`);
+                    }
+                }
+            }
+        }
+        this.updateActiveSessions();
+    }
+
+    /**
+     * Clears all PSK sessions.
+     */
+    clearAll(): void {
+        for (const address of this.sessions.keys()) {
+            this.removePersistedState(address);
+        }
+        this.sessions.clear();
+        this.updateActiveSessions();
+    }
+
+    private persistState(address: string, state: PSKState): void {
+        try {
+            const json = serializePSKState(state);
+            localStorage.setItem(PSK_STORAGE_PREFIX + address, json);
+        } catch {
+            console.warn(`[PSK] Failed to persist state for ${address}`);
+        }
+    }
+
+    private removePersistedState(address: string): void {
+        localStorage.removeItem(PSK_STORAGE_PREFIX + address);
+    }
+
+    private updateActiveSessions(): void {
+        this.activeSessions.set(Array.from(this.sessions.keys()));
+    }
+}

--- a/src/app/core/psk/psk.spec.ts
+++ b/src/app/core/psk/psk.spec.ts
@@ -1,0 +1,501 @@
+/**
+ * PSK Protocol v1.1 - Tests
+ *
+ * Tests for ratchet derivation, envelope encoding, encryption round-trip,
+ * counter state management, and exchange URI parsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { x25519 } from '@noble/curves/ed25519.js';
+import { deriveEncryptionKeys } from 'ts-algochat';
+
+import { PSK_PROTOCOL, PSK_HKDF } from './psk-types';
+import {
+    deriveSessionPSK,
+    derivePositionPSK,
+    derivePSKAtCounter,
+} from './psk-ratchet';
+import {
+    encodePSKEnvelope,
+    decodePSKEnvelope,
+    isPSKMessage,
+} from './psk-envelope';
+import {
+    pskEncryptMessage,
+    pskDecryptMessage,
+} from './psk-encryption';
+import {
+    createPSKState,
+    advanceSendCounter,
+    validateReceiveCounter,
+    recordReceivedCounter,
+    serializePSKState,
+    deserializePSKState,
+} from './psk-state';
+import {
+    createPSKExchangeURI,
+    parsePSKExchangeURI,
+    generatePSK,
+} from './psk-exchange';
+
+// --- Helpers ---
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+    }
+    return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    return Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+// Test key derivation (matches test-vectors.ts)
+const ALICE_SEED_HEX = '0000000000000000000000000000000000000000000000000000000000000001';
+const BOB_SEED_HEX = '0000000000000000000000000000000000000000000000000000000000000002';
+
+function getAliceKeys() {
+    return deriveEncryptionKeys(hexToBytes(ALICE_SEED_HEX));
+}
+
+function getBobKeys() {
+    return deriveEncryptionKeys(hexToBytes(BOB_SEED_HEX));
+}
+
+// Test vectors (initial PSK = 32 bytes of 0xAA)
+const INITIAL_PSK_HEX = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const RATCHET_VECTORS = {
+    session0: 'a031707ea9e9e50bd8ea4eb9a2bd368465ea1aff14caab293d38954b4717e888',
+    session1: '994cffbb4f84fa5410d44574bb9fa7408a8c2f1ed2b3a00f5168fc74c71f7cea',
+    counter0: '2918fd486b9bd024d712f6234b813c0f4167237d60c2c1fca37326b20497c165',
+    counter99: '5b48a50a25261f6b63fe9c867b46be46de4d747c3477db6290045ba519a4d38b',
+    counter100: '7a15d3add6a28858e6a1f1ea0d22bdb29b7e129a1330c4908d9b46a460992694',
+};
+
+// --- Tests ---
+
+describe('PSK Ratchet Vectors', () => {
+    const initialPSK = hexToBytes(INITIAL_PSK_HEX);
+
+    it('derives correct session 0 PSK', () => {
+        const session0 = deriveSessionPSK(initialPSK, 0);
+        expect(bytesToHex(session0)).toBe(RATCHET_VECTORS.session0);
+    });
+
+    it('derives correct session 1 PSK', () => {
+        const session1 = deriveSessionPSK(initialPSK, 1);
+        expect(bytesToHex(session1)).toBe(RATCHET_VECTORS.session1);
+    });
+
+    it('derives correct counter 0 PSK (session 0, position 0)', () => {
+        const counter0 = derivePSKAtCounter(initialPSK, 0);
+        expect(bytesToHex(counter0)).toBe(RATCHET_VECTORS.counter0);
+    });
+
+    it('derives correct counter 99 PSK (session 0, position 99)', () => {
+        const counter99 = derivePSKAtCounter(initialPSK, 99);
+        expect(bytesToHex(counter99)).toBe(RATCHET_VECTORS.counter99);
+    });
+
+    it('derives correct counter 100 PSK (session 1, position 0)', () => {
+        const counter100 = derivePSKAtCounter(initialPSK, 100);
+        expect(bytesToHex(counter100)).toBe(RATCHET_VECTORS.counter100);
+    });
+
+    it('matches manual two-step derivation', () => {
+        // counter 0 = session 0, position 0
+        const session0 = deriveSessionPSK(initialPSK, 0);
+        const pos0 = derivePositionPSK(session0, 0);
+        const counter0 = derivePSKAtCounter(initialPSK, 0);
+        expect(bytesToHex(pos0)).toBe(bytesToHex(counter0));
+
+        // counter 100 = session 1, position 0
+        const session1 = deriveSessionPSK(initialPSK, 1);
+        const pos0s1 = derivePositionPSK(session1, 0);
+        const counter100 = derivePSKAtCounter(initialPSK, 100);
+        expect(bytesToHex(pos0s1)).toBe(bytesToHex(counter100));
+    });
+
+    it('matches raw HKDF computation', () => {
+        const sessionSalt = new TextEncoder().encode(PSK_HKDF.SESSION_SALT);
+        const positionSalt = new TextEncoder().encode(PSK_HKDF.POSITION_SALT);
+
+        // Session 0 via raw HKDF
+        const info0 = new Uint8Array(4);
+        const rawSession0 = hkdf(sha256, initialPSK, sessionSalt, info0, 32);
+        expect(bytesToHex(rawSession0)).toBe(RATCHET_VECTORS.session0);
+
+        // Counter 99 via raw HKDF
+        const info99 = new Uint8Array(4);
+        new DataView(info99.buffer).setUint32(0, 99, false);
+        const rawCounter99 = hkdf(sha256, rawSession0, positionSalt, info99, 32);
+        expect(bytesToHex(rawCounter99)).toBe(RATCHET_VECTORS.counter99);
+    });
+});
+
+describe('PSK Envelope', () => {
+    it('encodes and decodes roundtrip', () => {
+        const aliceKeys = getAliceKeys();
+        const bobKeys = getBobKeys();
+        const initialPSK = hexToBytes(INITIAL_PSK_HEX);
+
+        const envelope = pskEncryptMessage(
+            'Hello PSK!',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            0
+        );
+
+        const encoded = encodePSKEnvelope(envelope);
+        expect(encoded.length).toBeGreaterThanOrEqual(PSK_PROTOCOL.HEADER_SIZE + PSK_PROTOCOL.TAG_SIZE);
+
+        const decoded = decodePSKEnvelope(encoded);
+        expect(decoded.version).toBe(PSK_PROTOCOL.VERSION);
+        expect(decoded.protocolId).toBe(PSK_PROTOCOL.PROTOCOL_ID);
+        expect(decoded.counter).toBe(0);
+        expect(bytesToHex(decoded.senderPublicKey)).toBe(bytesToHex(aliceKeys.publicKey));
+        expect(bytesToHex(decoded.ephemeralPublicKey)).toBe(bytesToHex(envelope.ephemeralPublicKey));
+        expect(bytesToHex(decoded.nonce)).toBe(bytesToHex(envelope.nonce));
+        expect(bytesToHex(decoded.encryptedSenderKey)).toBe(bytesToHex(envelope.encryptedSenderKey));
+        expect(bytesToHex(decoded.ciphertext)).toBe(bytesToHex(envelope.ciphertext));
+    });
+
+    it('detects PSK messages correctly', () => {
+        const aliceKeys = getAliceKeys();
+        const bobKeys = getBobKeys();
+        const initialPSK = hexToBytes(INITIAL_PSK_HEX);
+
+        const envelope = pskEncryptMessage(
+            'test',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            42
+        );
+
+        const encoded = encodePSKEnvelope(envelope);
+        expect(isPSKMessage(encoded)).toBe(true);
+
+        // v1 protocol 0x01 is not a PSK message
+        expect(isPSKMessage(new Uint8Array([0x01, 0x01, 0x00]))).toBe(false);
+
+        // Too short
+        expect(isPSKMessage(new Uint8Array([0x01, 0x02]))).toBe(false);
+    });
+
+    it('preserves counter value', () => {
+        const aliceKeys = getAliceKeys();
+        const bobKeys = getBobKeys();
+        const initialPSK = hexToBytes(INITIAL_PSK_HEX);
+
+        for (const counter of [0, 1, 99, 100, 1000, 65535, 0xFFFFFFFF]) {
+            const envelope = pskEncryptMessage(
+                'counter test',
+                aliceKeys.publicKey,
+                bobKeys.publicKey,
+                initialPSK,
+                counter
+            );
+            const encoded = encodePSKEnvelope(envelope);
+            const decoded = decodePSKEnvelope(encoded);
+            expect(decoded.counter).toBe(counter);
+        }
+    });
+});
+
+describe('PSK Encryption Round-Trip', () => {
+    const aliceKeys = getAliceKeys();
+    const bobKeys = getBobKeys();
+    const initialPSK = hexToBytes(INITIAL_PSK_HEX);
+
+    it('encrypts and decrypts as recipient', () => {
+        const envelope = pskEncryptMessage(
+            'Hello from PSK!',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            0
+        );
+
+        const decrypted = pskDecryptMessage(
+            envelope,
+            bobKeys.privateKey,
+            bobKeys.publicKey,
+            initialPSK
+        );
+
+        expect(decrypted).not.toBeNull();
+        expect(decrypted!.text).toBe('Hello from PSK!');
+        expect(decrypted!.counter).toBe(0);
+    });
+
+    it('sender can decrypt own message', () => {
+        const envelope = pskEncryptMessage(
+            'Self-decrypt test',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            5
+        );
+
+        const decrypted = pskDecryptMessage(
+            envelope,
+            aliceKeys.privateKey,
+            aliceKeys.publicKey,
+            initialPSK
+        );
+
+        expect(decrypted).not.toBeNull();
+        expect(decrypted!.text).toBe('Self-decrypt test');
+        expect(decrypted!.counter).toBe(5);
+    });
+
+    it('decrypts with different counter values', () => {
+        for (const counter of [0, 1, 50, 99, 100, 200]) {
+            const msg = `Counter ${counter}`;
+            const envelope = pskEncryptMessage(
+                msg,
+                aliceKeys.publicKey,
+                bobKeys.publicKey,
+                initialPSK,
+                counter
+            );
+
+            const decrypted = pskDecryptMessage(
+                envelope,
+                bobKeys.privateKey,
+                bobKeys.publicKey,
+                initialPSK
+            );
+
+            expect(decrypted).not.toBeNull();
+            expect(decrypted!.text).toBe(msg);
+        }
+    });
+
+    it('handles unicode messages', () => {
+        const envelope = pskEncryptMessage(
+            'Hello! \u{1F44B} PSK messaging \u{1F512}',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            0
+        );
+
+        const decrypted = pskDecryptMessage(
+            envelope,
+            bobKeys.privateKey,
+            bobKeys.publicKey,
+            initialPSK
+        );
+
+        expect(decrypted).not.toBeNull();
+        expect(decrypted!.text).toBe('Hello! \u{1F44B} PSK messaging \u{1F512}');
+    });
+
+    it('wrong PSK fails to decrypt', () => {
+        const envelope = pskEncryptMessage(
+            'Secret',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            0
+        );
+
+        const wrongPSK = new Uint8Array(32).fill(0xBB);
+        expect(() => {
+            pskDecryptMessage(
+                envelope,
+                bobKeys.privateKey,
+                bobKeys.publicKey,
+                wrongPSK
+            );
+        }).toThrow();
+    });
+
+    it('wrong private key fails to decrypt', () => {
+        const envelope = pskEncryptMessage(
+            'Secret',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            0
+        );
+
+        const wrongKey = x25519.utils.randomPrivateKey();
+        const wrongPub = x25519.getPublicKey(wrongKey);
+
+        expect(() => {
+            pskDecryptMessage(envelope, wrongKey, wrongPub, initialPSK);
+        }).toThrow();
+    });
+
+    it('full encode/decode/decrypt roundtrip', () => {
+        const envelope = pskEncryptMessage(
+            'Full roundtrip',
+            aliceKeys.publicKey,
+            bobKeys.publicKey,
+            initialPSK,
+            7
+        );
+
+        const encoded = encodePSKEnvelope(envelope);
+        expect(isPSKMessage(encoded)).toBe(true);
+
+        const decoded = decodePSKEnvelope(encoded);
+        const decrypted = pskDecryptMessage(
+            decoded,
+            bobKeys.privateKey,
+            bobKeys.publicKey,
+            initialPSK
+        );
+
+        expect(decrypted).not.toBeNull();
+        expect(decrypted!.text).toBe('Full roundtrip');
+        expect(decrypted!.counter).toBe(7);
+    });
+});
+
+describe('PSK State Management', () => {
+    it('creates state with zero counters', () => {
+        const psk = new Uint8Array(32).fill(0xAA);
+        const state = createPSKState(psk);
+
+        expect(state.sendCounter).toBe(0);
+        expect(state.receiveCounter).toBe(0);
+        expect(state.receivedCounters.size).toBe(0);
+    });
+
+    it('rejects invalid PSK length', () => {
+        expect(() => createPSKState(new Uint8Array(16))).toThrow();
+        expect(() => createPSKState(new Uint8Array(64))).toThrow();
+    });
+
+    it('advances send counter monotonically', () => {
+        const state = createPSKState(new Uint8Array(32).fill(0xAA));
+
+        expect(advanceSendCounter(state)).toBe(0);
+        expect(advanceSendCounter(state)).toBe(1);
+        expect(advanceSendCounter(state)).toBe(2);
+        expect(state.sendCounter).toBe(3);
+    });
+
+    it('validates receive counter within window', () => {
+        const state = createPSKState(new Uint8Array(32).fill(0xAA));
+
+        // First message - any counter accepted
+        expect(validateReceiveCounter(state, 0)).toBe(true);
+        recordReceivedCounter(state, 0);
+
+        // Within window
+        expect(validateReceiveCounter(state, 100)).toBe(true);
+        recordReceivedCounter(state, 100);
+
+        // Within window of new high-water mark
+        expect(validateReceiveCounter(state, 50)).toBe(true);
+        expect(validateReceiveCounter(state, 200)).toBe(true);
+
+        // Outside window (too far ahead)
+        expect(validateReceiveCounter(state, 301)).toBe(false);
+    });
+
+    it('rejects replay (duplicate counter)', () => {
+        const state = createPSKState(new Uint8Array(32).fill(0xAA));
+
+        expect(validateReceiveCounter(state, 5)).toBe(true);
+        recordReceivedCounter(state, 5);
+
+        // Same counter should be rejected
+        expect(validateReceiveCounter(state, 5)).toBe(false);
+    });
+
+    it('prunes old counters', () => {
+        const state = createPSKState(new Uint8Array(32).fill(0xAA));
+
+        // Record counter 0
+        recordReceivedCounter(state, 0);
+        expect(state.receivedCounters.has(0)).toBe(true);
+
+        // Advance well past window
+        recordReceivedCounter(state, 500);
+        // Counter 0 should be pruned (outside window of 200 from 500)
+        expect(state.receivedCounters.has(0)).toBe(false);
+    });
+
+    it('serializes and deserializes', () => {
+        const state = createPSKState(new Uint8Array(32).fill(0xAA));
+        advanceSendCounter(state);
+        advanceSendCounter(state);
+        recordReceivedCounter(state, 10);
+        recordReceivedCounter(state, 15);
+
+        const json = serializePSKState(state);
+        const restored = deserializePSKState(json);
+
+        expect(restored.sendCounter).toBe(2);
+        expect(restored.receiveCounter).toBe(15);
+        expect(restored.receivedCounters.has(10)).toBe(true);
+        expect(restored.receivedCounters.has(15)).toBe(true);
+        expect(bytesToHex(restored.initialPSK)).toBe(bytesToHex(state.initialPSK));
+    });
+});
+
+describe('PSK Exchange URI', () => {
+    it('creates and parses URI roundtrip', () => {
+        const psk = new Uint8Array(32).fill(0x42);
+        const address = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ';
+
+        const uri = createPSKExchangeURI(address, psk, 'Alice');
+        expect(uri).toContain('algochat-psk://v1?');
+        expect(uri).toContain('addr=' + address);
+        expect(uri).toContain('label=Alice');
+
+        const parsed = parsePSKExchangeURI(uri);
+        expect(parsed.address).toBe(address);
+        expect(parsed.label).toBe('Alice');
+        expect(bytesToHex(parsed.psk)).toBe(bytesToHex(psk));
+    });
+
+    it('handles special characters in label', () => {
+        const psk = generatePSK();
+        const uri = createPSKExchangeURI('ADDR', psk, 'Bob & Alice <3');
+        const parsed = parsePSKExchangeURI(uri);
+        expect(parsed.label).toBe('Bob & Alice <3');
+    });
+
+    it('handles empty label', () => {
+        const psk = generatePSK();
+        const uri = createPSKExchangeURI('ADDR', psk, '');
+        const parsed = parsePSKExchangeURI(uri);
+        expect(parsed.label).toBe('');
+    });
+
+    it('rejects invalid URI scheme', () => {
+        expect(() => parsePSKExchangeURI('https://example.com')).toThrow();
+    });
+
+    it('rejects missing parameters', () => {
+        expect(() => parsePSKExchangeURI('algochat-psk://v1?psk=AAAA')).toThrow();
+        expect(() => parsePSKExchangeURI('algochat-psk://v1?addr=AAAA')).toThrow();
+    });
+
+    it('rejects invalid PSK length', () => {
+        expect(() => createPSKExchangeURI('ADDR', new Uint8Array(16), 'test')).toThrow();
+    });
+
+    it('generates random 32-byte PSK', () => {
+        const psk = generatePSK();
+        expect(psk.length).toBe(32);
+
+        // Should be different each time
+        const psk2 = generatePSK();
+        expect(bytesToHex(psk)).not.toBe(bytesToHex(psk2));
+    });
+});


### PR DESCRIPTION
## Summary
- Add PSK (pre-shared key) messaging protocol v1.1 implementation
- Two-level HKDF ratchet for per-message key derivation (session/position)
- Hybrid ECDH+PSK encryption with ChaCha20-Poly1305
- Counter-based replay protection with sliding window (+/- 200)
- Exchange URI scheme for out-of-band PSK sharing
- Angular service wrapper with localStorage persistence
- Test suite with cross-implementation reference vectors

## Test plan
- [x] `bun run build` compiles without errors
- [ ] `bun run test` passes all PSK spec tests
- [ ] Ratchet test vectors match reference implementation
- [ ] Envelope encode/decode roundtrip works
- [ ] Encryption roundtrip (recipient + sender self-decrypt)
- [ ] Counter state management (window, replay rejection, pruning)
- [ ] Exchange URI create/parse roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)