### PR TITLE
Fix Vitest ESM resolution for ts-algochat

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    // ts-algochat uses "moduleResolution": "bundler" so its compiled ESM
+    // output omits .js extensions. Vite/Vitest needs this to resolve those
+    // extensionless imports under Node.js ESM resolution.
+    extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
+  },
   test: {
     include: ['src/**/*.spec.ts'],
     globals: true,


### PR DESCRIPTION
## Summary
- Fixes CI test failure: `Cannot find module '.../dist/models/types'`
- The `@corvidlabs/ts-algochat` package uses `"moduleResolution": "bundler"` in its tsconfig, so compiled ESM output omits `.js` extensions on internal imports
- Angular's esbuild bundler handles this fine, but Vitest uses Node.js strict ESM resolution which requires explicit extensions
- Adding `resolve.extensions` to `vitest.config.ts` tells Vite to resolve extensionless imports

## Root cause
`ts-algochat` compiles with `"moduleResolution": "bundler"` → emits `from './types'` instead of `from './types.js'` → Node.js ESM rejects it

## Test plan
- [ ] CI tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)