### PR TITLE
fix: use server.deps.inline for Vitest ESM resolution

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+    globals: true,
+    server: {
+      deps: {
+        // ts-algochat uses "moduleResolution": "bundler" so its compiled ESM
+        // omits .js extensions. Inlining it lets Vite's resolver handle the
+        // extensionless imports instead of Node.js strict ESM resolution.
+        inline: ['@corvidlabs/ts-algochat'],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Fixes the CI test failure that persists after #7
- `resolve.extensions` only applies to **source files**, not `node_modules` — so it doesn't actually fix the extensionless import issue in `@corvidlabs/ts-algochat`
- Uses `server.deps.inline` instead, which tells Vitest to process `ts-algochat` through Vite's module resolver (which handles extensionless imports like a bundler) instead of deferring to Node.js strict ESM resolution
- All 31 tests pass locally ✅

## Why the previous fix didn't work
PR #7 added `resolve.extensions` to `vitest.config.ts`. This config tells Vite what extensions to try when resolving imports **in your source code**. However, packages in `node_modules` are "externalized" by default — they bypass Vite's resolver entirely and are loaded directly by Node.js. Since Node.js strict ESM requires explicit `.js` extensions, the extensionless `from './models/types'` in `ts-algochat` still fails.

## What this fix does
`server.deps.inline: ['@corvidlabs/ts-algochat']` tells Vitest to **inline** (not externalize) this package. Vite's own module resolver processes it, which natively supports extensionless imports — the same way Angular's esbuild bundler does.

## Test plan
- [x] `vitest run` passes locally (31/31 tests)
- [ ] CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)