### PR TITLE
fix: make PSK state network-aware to prevent cross-network desync

### DIFF
--- a/src/app/features/chat/chat.component.ts
+++ b/src/app/features/chat/chat.component.ts
@@ -930,6 +930,8 @@ export class ChatComponent implements OnInit, OnDestroy {
 
     protected async switchNetwork(): Promise<void> {
         this.networkService.toggle();
+        // Reload PSK entries for the new network so counters match
+        await this.pskService.reloadForNetwork();
         // Reload data for the new network
         this.conversations.set([]);
         this.selectedMessages.set([]);


### PR DESCRIPTION
## Summary
- PSK keys and counter state were stored under a single `algochat_psk` localStorage key regardless of active network, causing counter desync when switching between testnet and mainnet
- Storage is now scoped per network: `algochat_psk_testnet` / `algochat_psk_mainnet`
- Existing data is automatically migrated to the testnet-scoped key on first load
- PSK entries are reloaded when the user toggles networks

## Changes
- **`src/app/core/services/psk.service.ts`** — Inject `NetworkService`, use network-scoped storage keys, add `reloadForNetwork()` method, add legacy data migration
- **`src/app/features/chat/chat.component.ts`** — Call `pskService.reloadForNetwork()` on network switch

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 31 tests pass (`bun run test`)
- [ ] Manual: switch testnet → mainnet, verify PSK counters are independent
- [ ] Manual: verify legacy `algochat_psk` key is migrated to `algochat_psk_testnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)