### PR TITLE
feat: markdown rendering & per-message copy buttons

### DIFF
--- a/src/app/core/utils/markdown.ts
+++ b/src/app/core/utils/markdown.ts
@@ -1,0 +1,213 @@
+/**
+ * Shared markdown renderer for AlgoChat.
+ *
+ * Converts a subset of Markdown to HTML suitable for display inside chat bubbles.
+ * Supports: headings, bold, italic, strikethrough, inline code, code blocks,
+ * links, images (as links), blockquotes, horizontal rules, unordered &
+ * ordered lists, and tables.
+ *
+ * No external dependencies — pure function, safe for use with [innerHTML].
+ */
+
+/** Escape HTML entities so user content is never interpreted as markup. */
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+/**
+ * Apply inline markdown transformations (bold, italic, code, links, etc.)
+ * to a single line of already-HTML-escaped text.
+ */
+function renderInline(line: string): string {
+    // Inline code (must come first to prevent inner transformations)
+    // We temporarily replace inline code with placeholders, then restore after other transforms.
+    const codeSpans: string[] = [];
+    let processed = line.replace(/`([^`]+)`/g, (_m, code) => {
+        const idx = codeSpans.length;
+        codeSpans.push(`<code>${code}</code>`);
+        return `\x00CODE${idx}\x00`;
+    });
+
+    // Images → rendered as linked alt text (terminal-friendly)
+    processed = processed.replace(
+        /!\[([^\]]*)\]\(([^)]+)\)/g,
+        '<a href="$2" target="_blank" rel="noopener" class="md-link">🖼 $1</a>',
+    );
+
+    // Links
+    processed = processed.replace(
+        /\[([^\]]+)\]\(([^)]+)\)/g,
+        '<a href="$2" target="_blank" rel="noopener" class="md-link">$1</a>',
+    );
+
+    // Bold + italic (***text*** or ___text___)
+    processed = processed.replace(/\*{3}([^*]+)\*{3}/g, '<strong><em>$1</em></strong>');
+    processed = processed.replace(/_{3}([^_]+)_{3}/g, '<strong><em>$1</em></strong>');
+
+    // Bold (**text** or __text__)
+    processed = processed.replace(/\*{2}([^*]+)\*{2}/g, '<strong>$1</strong>');
+    processed = processed.replace(/_{2}([^_]+)_{2}/g, '<strong>$1</strong>');
+
+    // Italic (*text* or _text_) — avoid matching inside words for underscores
+    processed = processed.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+    processed = processed.replace(/(?<!\w)_([^_]+)_(?!\w)/g, '<em>$1</em>');
+
+    // Strikethrough (~~text~~)
+    processed = processed.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+
+    // Restore inline code
+    processed = processed.replace(/\x00CODE(\d+)\x00/g, (_m, idx) => codeSpans[+idx]);
+
+    return processed;
+}
+
+/**
+ * Render a markdown string to HTML.
+ *
+ * Block-level constructs are processed line-by-line; inline transforms are
+ * applied within each block.
+ */
+export function renderMarkdown(text: string): string {
+    const escaped = escapeHtml(text);
+    const lines = escaped.split('\n');
+    const out: string[] = [];
+
+    let i = 0;
+
+    while (i < lines.length) {
+        const line = lines[i];
+
+        // ── Fenced code blocks ──────────────────────────────────
+        const fenceMatch = line.match(/^```(\w*)/);
+        if (fenceMatch) {
+            const lang = fenceMatch[1];
+            const codeLines: string[] = [];
+            i++;
+            while (i < lines.length && !lines[i].startsWith('```')) {
+                codeLines.push(lines[i]);
+                i++;
+            }
+            i++; // skip closing ```
+            const langAttr = lang ? ` data-lang="${lang}"` : '';
+            out.push(`<pre class="md-codeblock"${langAttr}><code>${codeLines.join('\n')}</code></pre>`);
+            continue;
+        }
+
+        // ── Horizontal rule ─────────────────────────────────────
+        if (/^(\s*[-*_]\s*){3,}$/.test(line)) {
+            out.push('<hr class="md-hr">');
+            i++;
+            continue;
+        }
+
+        // ── Headings ────────────────────────────────────────────
+        const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+        if (headingMatch) {
+            const level = headingMatch[1].length;
+            out.push(`<div class="md-h md-h${level}">${renderInline(headingMatch[2])}</div>`);
+            i++;
+            continue;
+        }
+
+        // ── Table ───────────────────────────────────────────────
+        if (line.includes('|') && i + 1 < lines.length && /^\s*\|?\s*[-:]+[-| :]*$/.test(lines[i + 1])) {
+            const tableLines: string[] = [line];
+            const separatorLine = lines[i + 1];
+            i += 2; // skip header + separator
+            while (i < lines.length && lines[i].includes('|')) {
+                tableLines.push(lines[i]);
+                i++;
+            }
+            out.push(renderTable(tableLines, separatorLine));
+            continue;
+        }
+
+        // ── Blockquote ──────────────────────────────────────────
+        if (line.startsWith('&gt; ') || line === '&gt;') {
+            const quoteLines: string[] = [];
+            while (i < lines.length && (lines[i].startsWith('&gt; ') || lines[i] === '&gt;')) {
+                quoteLines.push(lines[i].replace(/^&gt;\s?/, ''));
+                i++;
+            }
+            out.push(`<blockquote class="md-blockquote">${quoteLines.map(renderInline).join('<br>')}</blockquote>`);
+            continue;
+        }
+
+        // ── Unordered list ──────────────────────────────────────
+        if (/^\s*[-*+]\s+/.test(line)) {
+            const listItems: string[] = [];
+            while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i])) {
+                listItems.push(lines[i].replace(/^\s*[-*+]\s+/, ''));
+                i++;
+            }
+            out.push('<ul class="md-list">' + listItems.map(li => `<li>${renderInline(li)}</li>`).join('') + '</ul>');
+            continue;
+        }
+
+        // ── Ordered list ────────────────────────────────────────
+        if (/^\s*\d+[.)]\s+/.test(line)) {
+            const listItems: string[] = [];
+            while (i < lines.length && /^\s*\d+[.)]\s+/.test(lines[i])) {
+                listItems.push(lines[i].replace(/^\s*\d+[.)]\s+/, ''));
+                i++;
+            }
+            out.push('<ol class="md-list">' + listItems.map(li => `<li>${renderInline(li)}</li>`).join('') + '</ol>');
+            continue;
+        }
+
+        // ── Empty line → break ──────────────────────────────────
+        if (line.trim() === '') {
+            out.push('<br>');
+            i++;
+            continue;
+        }
+
+        // ── Paragraph / normal text ─────────────────────────────
+        out.push(renderInline(line));
+        i++;
+    }
+
+    return out.join('\n');
+}
+
+/**
+ * Render a pipe-delimited table.
+ * `rows` includes the header as the first element (separator is passed separately).
+ */
+function renderTable(rows: string[], separator: string): string {
+    const parseRow = (row: string): string[] =>
+        row.split('|').map(c => c.trim()).filter((_c, i, arr) => i > 0 && i < arr.length); // drop leading/trailing empty
+
+    // Determine alignment from separator row
+    const alignCells = parseRow(separator);
+    const aligns: string[] = alignCells.map(cell => {
+        const left = cell.startsWith(':');
+        const right = cell.endsWith(':');
+        if (left && right) return 'center';
+        if (right) return 'right';
+        return 'left';
+    });
+
+    const headerCells = parseRow(rows[0]);
+    const bodyRows = rows.slice(1);
+
+    let html = '<table class="md-table"><thead><tr>';
+    for (let c = 0; c < headerCells.length; c++) {
+        html += `<th style="text-align:${aligns[c] ?? 'left'}">${renderInline(headerCells[c])}</th>`;
+    }
+    html += '</tr></thead><tbody>';
+    for (const row of bodyRows) {
+        html += '<tr>';
+        const cells = parseRow(row);
+        for (let c = 0; c < headerCells.length; c++) {
+            html += `<td style="text-align:${aligns[c] ?? 'left'}">${renderInline(cells[c] ?? '')}</td>`;
+        }
+        html += '</tr>';
+    }
+    html += '</tbody></table>';
+    return html;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -548,6 +548,192 @@ i.nes-icon {
 }
 
 // ============================================
+// Per-Message Copy Button
+// ============================================
+
+.copy-msg-btn {
+    background: transparent;
+    border: 1px solid var(--theme-border-color);
+    color: var(--theme-secondary-text);
+    font-family: inherit;
+    font-size: 8px;
+    padding: 1px 5px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+    line-height: 1.2;
+    min-width: 0;
+    min-height: 0;
+
+    &:hover {
+        color: var(--theme-primary);
+        border-color: var(--theme-primary);
+    }
+}
+
+.message-bubble:hover .copy-msg-btn {
+    opacity: 1;
+}
+
+// ============================================
+// Markdown Content Styles
+// ============================================
+
+.md-content {
+    font-size: 16px;
+    line-height: 1.6;
+    margin-bottom: 0.5rem;
+    color: inherit;
+    word-break: break-word;
+
+    // Override white-space: pre-wrap from .message-content
+    white-space: normal;
+
+    // Headings
+    .md-h {
+        font-weight: bold;
+        margin: 0.5em 0 0.25em;
+        color: var(--theme-warning);
+    }
+
+    .md-h1 { font-size: 1.4em; }
+    .md-h2 { font-size: 1.25em; }
+    .md-h3 { font-size: 1.1em; }
+    .md-h4 { font-size: 1em; }
+    .md-h5 { font-size: 0.9em; }
+    .md-h6 { font-size: 0.85em; }
+
+    // Bold & Italic
+    strong { color: var(--theme-primary-text); font-weight: bold; }
+    em { font-style: italic; }
+    del { text-decoration: line-through; opacity: 0.7; }
+
+    // Inline code
+    code {
+        font-family: 'Dogica Pixel', monospace;
+        font-size: 0.85em;
+        color: var(--theme-primary);
+        background: rgba(0, 0, 0, 0.35);
+        padding: 1px 4px;
+        border: 1px solid var(--theme-border-color);
+    }
+
+    // Code blocks
+    .md-codeblock {
+        background: rgba(0, 0, 0, 0.4);
+        border: 2px solid var(--theme-border-color);
+        padding: 0.75rem;
+        margin: 0.5rem 0;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+
+        code {
+            background: none;
+            border: none;
+            padding: 0;
+            font-size: 0.85em;
+            line-height: 1.8;
+            color: var(--theme-primary);
+        }
+    }
+
+    // Links
+    .md-link {
+        color: var(--theme-primary);
+        text-decoration: underline;
+        text-decoration-style: dotted;
+
+        &:hover {
+            color: var(--theme-primary-accent);
+            text-decoration-style: solid;
+        }
+    }
+
+    // Blockquotes
+    .md-blockquote {
+        border-left: 4px solid var(--theme-primary-accent);
+        padding: 0.5rem 0.75rem;
+        margin: 0.5rem 0;
+        background: rgba(0, 0, 0, 0.2);
+        color: var(--theme-secondary-text);
+        font-style: italic;
+    }
+
+    // Horizontal rule
+    .md-hr {
+        border: none;
+        border-top: 2px solid var(--theme-border-color);
+        margin: 0.75rem 0;
+    }
+
+    // Lists
+    .md-list {
+        margin: 0.5rem 0;
+        padding-left: 1.5rem;
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+    }
+
+    ul.md-list {
+        list-style: square;
+    }
+
+    ol.md-list {
+        list-style: decimal;
+    }
+
+    // Tables
+    .md-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 0.5rem 0;
+        font-size: 0.85em;
+
+        th, td {
+            border: 2px solid var(--theme-border-color);
+            padding: 0.4rem 0.6rem;
+        }
+
+        th {
+            background: rgba(0, 0, 0, 0.3);
+            color: var(--theme-warning);
+            font-weight: bold;
+        }
+
+        td {
+            background: rgba(0, 0, 0, 0.15);
+        }
+
+        tr:hover td {
+            background: rgba(0, 0, 0, 0.25);
+        }
+    }
+}
+
+// Mobile: Smaller markdown
+@media (max-width: 768px) {
+    .md-content {
+        font-size: 12px;
+
+        .md-codeblock {
+            padding: 0.5rem;
+            font-size: 10px;
+        }
+
+        .md-table {
+            font-size: 9px;
+
+            th, td {
+                padding: 0.2rem 0.3rem;
+            }
+        }
+    }
+}
+
+// ============================================
 // Conversation List
 // ============================================
 


### PR DESCRIPTION
## Summary
- **Markdown renderer** (`core/utils/markdown.ts`) — zero-dependency pure function supporting headings, bold, italic, strikethrough, inline code, fenced code blocks, links, images, blockquotes, horizontal rules, ordered & unordered lists, and pipe-delimited tables with alignment. XSS-safe via HTML escaping.
- **Per-message copy button** — each message bubble gets a `cp` button (visible on hover) that copies raw content to clipboard and shows `✓` confirmation for 1.5s.
- **Markdown CSS styles** — NES.css-compatible styles for all markdown elements, with responsive mobile breakpoints. Code blocks use Dogica Pixel font, tables have pixel-style borders, headings in warning color, links in theme primary.

## Changes
| File | What |
|------|------|
| `src/app/core/utils/markdown.ts` | New shared markdown renderer (213 lines) |
| `src/app/features/chat/chat.component.ts` | Import renderer, add `renderMd()` + `copyMessage()` methods, update template to use `[innerHTML]` with markdown + copy buttons |
| `src/styles.scss` | Add `.copy-msg-btn` and `.md-content` styles (~186 lines) |

## Test plan
- [ ] Send a message with **bold**, *italic*, `code`, and a [link](https://example.com) — verify they render correctly
- [ ] Send a multi-line message with a code block (triple backticks) — verify styled code block appears
- [ ] Hover over a message — verify the "cp" button appears
- [ ] Click the "cp" button — verify clipboard contains the raw text and button shows "✓"
- [ ] Check mobile view — verify responsive styles work and copy button is accessible
- [ ] Verify existing features (ALGO sending, PSK badges, pending/failed states) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)