### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,6 +3,16 @@ name: CD
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "packages/**"
+      - "public/**"
+      - "package.json"
+      - "bun.lock"
+      - "angular.json"
+      - "tsconfig*.json"
+      - "vitest.config.ts"
+      - ".github/workflows/CD.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,8 +27,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -46,6 +57,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,14 +3,39 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "packages/**"
+      - "public/**"
+      - "package.json"
+      - "bun.lock"
+      - "angular.json"
+      - "tsconfig*.json"
+      - "vitest.config.ts"
+      - ".github/workflows/CI.yml"
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "packages/**"
+      - "public/**"
+      - "package.json"
+      - "bun.lock"
+      - "angular.json"
+      - "tsconfig*.json"
+      - "vitest.config.ts"
+      - ".github/workflows/CI.yml"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
Standardizes the GitHub Actions workflows to mirror the CorvidLabs/merlin CI standard.

### CI.yml (push/PR CI)
- Add `paths:` filter on both `push` and `pull_request` (Angular/bun-ts set): `src/**`, `packages/**`, `public/**`, `package.json`, `bun.lock`, `angular.json`, `tsconfig*.json`, `vitest.config.ts`, plus `.github/workflows/CI.yml` — README/docs-only changes now trigger nothing.
- Add `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }`.
- Bump `actions/checkout@v4` -> `@v5`; add `timeout-minutes: 20` to the `test` job.
- Runner kept on `ubuntu-latest` (correct: PUBLIC repo -> GitHub-hosted only).

### CD.yml (GitHub Pages deploy)
- Add a site-source-scoped `paths:` filter to the `push` trigger so doc-only commits to main no longer redeploy the site (`workflow_dispatch` untouched).
- Existing `concurrency: pages` group preserved.
- Bump `actions/checkout@v4` -> `@v5`; add `timeout-minutes` to the `build` (20) and `deploy` (10) jobs.
- Runner kept on `ubuntu-latest` (correct for PUBLIC + Pages).

No `fledge.toml` present, so native `bun`/`ng`/`vitest` step logic is preserved unchanged.

Mirrors the CorvidLabs/merlin CI standard.